### PR TITLE
Logfilemode must not be set if guimode is enabled.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1151,7 +1151,7 @@ int main(int argc, char *argv[]) {
       ERROR("Usage error: piping is not possible with multiple input files");
   }
 
-  if (!isatty(2)) {
+  if (!isatty(2) && opts.guimode == 0) {
     logfilemode = 1;
     interactive = 0;
   }


### PR DESCRIPTION
Logfilemode must not be set if guimode is enabled because the GUI needs the progress information.
