### PR TITLE
Updated key server IP address to the most recent one (as of Aug 2017)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -545,7 +545,7 @@ char * generateRequest(void *bigkey, char *date) {
     fputs("\n", stderr);
   }
   
-  snprintf(result, 1024, "http://87.236.198.182/quelle_neu1.php\
+  snprintf(result, 1024, "http://185.195.80.111/quelle_neu1.php\
 ?code=%s\
 &AA=%s\
 &ZZ=%s", base64Encode(code, 512), email, date);


### PR DESCRIPTION
The OTR key server IP address changed a few days ago. I have updated it with one taken from an official client binary (obtained with 'strings'). Tested successfully.