### PR TITLE
replace semaphores with mutexes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LDFLAGS += -lcurl
 CFLAGS += $(shell getconf LFS_CFLAGS)
 LDFLAGS += $(shell getconf LFS_LDFLAGS)
 
-SRCS = src/md5.c src/blowfish.c src/main.c
+SRCS = src/md5.c src/blowfish.c src/sem.c src/main.c
 MAIN = otrtool
 
 OBJS = $(SRCS:.c=.o)

--- a/src/main.c
+++ b/src/main.c
@@ -10,9 +10,13 @@
 #include <termios.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#if _POSIX_THREADS > 0 && _POSIX_SEMAPHORES > 0
+#if _POSIX_THREADS > 0
   #include <pthread.h>
-  #include <semaphore.h>
+  #if _POSIX_SEMAPHORES > 0
+    #include <semaphore.h>
+  #else
+    #include "sem.h"
+  #endif
   #define MT 1
 #else
   #define MT 0

--- a/src/sem.c
+++ b/src/sem.c
@@ -12,11 +12,13 @@ int sem_init(sem_t *sem, int pshared, unsigned value) {
 
     ret = pthread_mutex_init(&sem->lock, NULL);
     if (ret != 0) {
+        errno = ret;
         return -1;
     }
 
     ret = pthread_cond_init(&sem->cond, NULL);
     if (ret != 0) {
+        errno = ret;
         return -1;
     }
 
@@ -29,11 +31,13 @@ int sem_destroy(sem_t *sem) {
 
     ret = pthread_mutex_destroy(&sem->lock);
     if (ret != 0) {
+        errno = ret;
         return -1;
     }
 
     ret = pthread_cond_destroy(&sem->cond);
     if (ret != 0) {
+        errno = ret;
         return -1;
     }
 
@@ -45,6 +49,7 @@ int sem_wait(sem_t *sem) {
 
     ret = pthread_mutex_lock(&sem->lock);
     if (ret != 0) {
+        errno = ret;
         return -1;
     }
 
@@ -52,6 +57,7 @@ int sem_wait(sem_t *sem) {
     if (sem->count == 0) {
         ret = pthread_cond_wait(&sem->cond, &sem->lock);
         if (ret != 0) {
+            errno = ret;
             return -1;
         }
     }
@@ -60,6 +66,7 @@ int sem_wait(sem_t *sem) {
     sem->count -= 1;
     ret = pthread_mutex_unlock(&sem->lock);
     if (ret != 0) {
+        errno = ret;
         return -1;
     }
 
@@ -71,6 +78,7 @@ int sem_post(sem_t *sem) {
 
     ret = pthread_mutex_lock(&sem->lock);
     if (ret != 0) {
+        errno = ret;
         return -1;
     }
 
@@ -78,11 +86,13 @@ int sem_post(sem_t *sem) {
     sem->count += 1;
     ret = pthread_cond_signal(&sem->cond);
     if (ret != 0) {
+        errno = ret;
         return -1;
     }
 
     ret = pthread_mutex_unlock(&sem->lock);
     if (ret != 0) {
+        errno = ret;
         return -1;
     }
 

--- a/src/sem.c
+++ b/src/sem.c
@@ -1,0 +1,92 @@
+#include <unistd.h>
+#if _POSIX_SEMAPHORES <= 0
+#include "sem.h"
+
+int sem_init(sem_t *sem, int pshared, unsigned value) {
+    if (pshared != 0) {
+        // we do not support process-shared semaphores
+        errno = ENOSYS;
+        return -1;
+    }
+    int ret;
+
+    ret = pthread_mutex_init(&sem->lock, NULL);
+    if (ret != 0) {
+        return -1;
+    }
+
+    ret = pthread_cond_init(&sem->cond, NULL);
+    if (ret != 0) {
+        return -1;
+    }
+
+    sem->count = value;
+    return 0;
+}
+
+int sem_destroy(sem_t *sem) {
+    int ret;
+
+    ret = pthread_mutex_destroy(&sem->lock);
+    if (ret != 0) {
+        return -1;
+    }
+
+    ret = pthread_cond_destroy(&sem->cond);
+    if (ret != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int sem_wait(sem_t *sem) {
+    int ret;
+
+    ret = pthread_mutex_lock(&sem->lock);
+    if (ret != 0) {
+        return -1;
+    }
+
+    // safely check the count
+    if (sem->count == 0) {
+        ret = pthread_cond_wait(&sem->cond, &sem->lock);
+        if (ret != 0) {
+            return -1;
+        }
+    }
+
+    // now, count > 0
+    sem->count -= 1;
+    ret = pthread_mutex_unlock(&sem->lock);
+    if (ret != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int sem_post(sem_t *sem) {
+    int ret;
+
+    ret = pthread_mutex_lock(&sem->lock);
+    if (ret != 0) {
+        return -1;
+    }
+
+    // increment and wake up other thread
+    sem->count += 1;
+    ret = pthread_cond_signal(&sem->cond);
+    if (ret != 0) {
+        return -1;
+    }
+
+    ret = pthread_mutex_unlock(&sem->lock);
+    if (ret != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+#endif /* _POSIX_SEMAPHORES */

--- a/src/sem.h
+++ b/src/sem.h
@@ -1,0 +1,21 @@
+/*
+ * sem.h -- unnamed semaphores for macOS
+ *
+ * This uses pthread_mutex and pthread_cond to make a custom semaphore type.
+ * Inspired by Brian's answer https://stackoverflow.com/a/48778462.
+ * Implemented from scratch by Keno Hassler, 2023 (copyright CC-0).
+ */
+
+#include <pthread.h>
+#include <sys/errno.h>
+
+typedef struct sem {
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    unsigned count;
+} sem_t;
+
+int sem_init(sem_t *sem, int pshared, unsigned value);
+int sem_destroy(sem_t *sem);
+int sem_wait(sem_t *sem);
+int sem_post(sem_t *sem);


### PR DESCRIPTION
This branch replaces semaphores with mutexes, increasing portability and enabling multi-threading on macOS.

The semaphores in this project only oscillate between 1 and 0, which makes it possible to replace calls to `sem_post` by `pthread_mutex_unlock` and `sem_wait` by `pthread_mutex_lock` without semantic changes.
This change enabled multi-threaded decoding on macOS and is a cleaner solution compared to #18.